### PR TITLE
build: release version 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-slugify",
   "description": "Library to slugify your strings within Ember.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "author": {
     "name": "Dazzling Fugu",


### PR DESCRIPTION
## Refactors
Remove duplicate code and flatten nested if branches (#177)

## Config

Update metadata and workflows (repository moved to @DazzlingFugu)

### Add compatibility for ESLint v8 (#182)
- upgrade [eslint](https://github.com/eslint/eslint) to v8
- add [@babel/core](https://github.com/babel/babel/tree/master/packages/babel-core) + [@babel/eslint-parser](https://www.npmjs.com/package/@babel/eslint-parser)
  - replace [babel-eslint](https://github.com/babel/babel-eslint/) which is archived and not compatible with ESLint v8

### Use correct configuration in `.template-lintrc.js` file (#182)
Extends `recommended` instead of `octane` which don't exists anymore

## Build

Remove webpack as devDeps (#171)

### Remove `ember-maybe-import-regenerator` (#161) 
This dependency is related to IE11 targets, which is no longer supported.

### @dependabot bumps
Bumps [@glimmer/tracking](https://github.com/glimmerjs/glimmer.js) from 1.0.4 to 1.1.2. (#187)
Bumps [ember-page-title](https://github.com/ember-cli/ember-page-title) from 6.2.2 to 7.0.0. (#185)
Bumps [terser](https://github.com/terser/terser) from 4.8.0 to 4.8.1. (#186)
Bumps [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers) from 2.6.0 to 2.8.1. (#184)
Bumps [prettier](https://github.com/prettier/prettier) from 2.5.1 to 2.6.2. (#183)
Bumps [ember-cli-dependency-checker](https://github.com/quaertym/ember-cli-dependency-checker) from 3.2.0 to 3.3.1. (#178)
Bumps [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) from 3.16.0 to 4.6.0. (#172)
Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.14.7 to 1.15.0. (#176)

## CI
Fix ember-try scenarios dependencies (#171)
