### PR TITLE
CI/ Build with node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   org:
     uses: DazzlingFugu/.github/.github/workflows/js--emberjs-addons.yml@master
     with:
-      node-version: 12
+      node-version: 16
       package-manager: yarn
       ember-try-scenarios: "[
         'ember-lts-3.20',

--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: DazzlingFugu/.github/.github/workflows/js--tag-release-publish.yml@master
     with:
-      node-version: 12
+      node-version: 16
       package-manager: yarn
     secrets:
       npm-automation-token: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "clean-css": "4.2.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "12.* || 14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## CI
### Build with node 16
Some dev dependencies used by `ember-slugify` started to drop support for node 12. The CI now build with node 16 so we can keep these dependencies up to date.