### PR TITLE
Revert "build(deps-dev): bump prettier from 2.8.0 to 2.8.1"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7495,9 +7495,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.5.1, prettier@^2.6.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
-  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
+  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
 
 printf@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Reverts #245 .

The PR #245 was green but after being merged `master` started failing:

```
2022-12-20T12:51:24.7540622Z ERROR Summary:
2022-12-20T12:51:24.7540842Z 
2022-12-20T12:51:24.7541976Z   - broccoliBuilderErrorStack: [undefined]
2022-12-20T12:51:24.7543661Z   - code: [undefined]
2022-12-20T12:51:24.7545738Z   - codeFrame: [undefined]
2022-12-20T12:51:24.7548098Z   - errorMessage: ember-qunit has the following unmet peerDependencies:
2022-12-20T12:51:24.7548744Z 
2022-12-20T12:51:24.7550534Z 	* ember-source: `^3.28 || ^4.0`; it was resolved to `3.20.7`
2022-12-20T12:51:24.7551317Z   - errorType: [undefined]
2022-12-20T12:51:24.7552920Z   - location:
2022-12-20T12:51:24.7553918Z     - column: [undefined]
2022-12-20T12:51:24.7556281Z     - file: [undefined]
2022-12-20T12:51:24.7557881Z     - line: [undefined]
2022-12-20T12:51:24.7559925Z   - message: ember-qunit has the following unmet peerDependencies:
2022-12-20T12:51:24.7560421Z 
2022-12-20T12:51:24.7562266Z 	* ember-source: `^3.28 || ^4.0`; it was resolved to `3.20.7`
2022-12-20T12:51:24.7563401Z   - name: Error
2022-12-20T12:51:24.7565260Z   - nodeAnnotation: [undefined]
2022-12-20T12:51:24.7566878Z   - nodeName: [undefined]
2022-12-20T12:51:24.7567939Z   - originalErrorMessage: [undefined]
2022-12-20T12:51:24.7570063Z   - stack: Error: ember-qunit has the following unmet peerDependencies:
2022-12-20T12:51:24.7571887Z 
2022-12-20T12:51:24.7572432Z 	* ember-source: `^3.28 || ^4.0`; it was resolved to `3.20.7`
```
