### PR TITLE
BREAKING tests(CI): drop support for ember < 3.28, not compatible wit…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       node-version: 16
       package-manager: yarn
       ember-try-scenarios: "[
-        'ember-lts-3.20',
-        'ember-lts-3.24',
         'ember-lts-3.28',
         'ember-release',
         'ember-beta',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -33,6 +33,9 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        // Can be mandatory again when ember-qunit will be compatible Ember 5
+        // https://github.com/emberjs/ember-qunit/issues/1026
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,22 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Breaking change
### Drop support for Ember < 3.28 (#254)
Ember 3.24 and older versions are no longer supported by `ember-qunit`. 

## CI
### Allow `ember-canary` to fail (#254)
`ember-canary` now relies on Ember 5, but `ember-qunit` is not compatible yet. `ember-canary` tests are allowed to fail as we're waiting for `ember-qunit` update.

Ref: https://github.com/emberjs/ember-qunit/issues/1026
