### PR TITLE
release version 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This library uses:
 
 ## Compatibility
 
-- Ember.js v3.20 or above
-- Ember CLI v3.20 or above
+- Ember.js v3.28 or above
+- Ember CLI v3.28 or above
 - Node.js v14 or above
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-slugify",
   "description": "Library to slugify your strings within Ember.",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "license": "MIT",
   "author": {
     "name": "Dazzling Fugu",


### PR DESCRIPTION
## Breaking change
### Ember 4.4 (#189)
- The addon has been updated to Ember 4.4 using [`ember-cli-update`](https://www.npmjs.com/package/ember-cli-update).
- This update **drops the support for jquery integration**.

### `ember-auto-import` v2 (#180)
- Bumps [ember-auto-import](https://github.com/ef4/ember-auto-import/tree/HEAD/packages/ember-auto-import) from 1.12.0 to 2.4.2.
- Add `webpack` explicitly in dev dependencies.
- Clean `ember-try` scenarion as `ember-auto-import` v2 and `webpack` are now presents in the default package.

### Drop support for Ember < 3.28 (#254)
Ember 3.24 and older versions are no longer supported by `ember-qunit`.

### Drop Node 12 support (#217)
Node 12 is incompatible with `ember-qunit` > 6.0.0.

## CI
### Build with node 16 (#196)
Some dev dependencies used by `ember-slugify` started to drop support for node 12. The CI now build with node 16 so we can keep these dependencies up to date.

### Allow `ember-canary` to fail (#254)
`ember-canary` now relies on Ember 5, but `ember-qunit` is not compatible yet. `ember-canary` tests are allowed to fail as we're waiting for `ember-qunit` update. Ref: https://github.com/emberjs/ember-qunit/issues/1026

## Build
### @dependabot bumps
Major:
- Bumps [ember-qunit](https://github.com/emberjs/ember-qunit) from 5.1.5 to 6.0.0.
- Bumps [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) from 4.12.0 to 5.5.1.
- Bumps [@embroider/test-setup](https://github.com/embroider-build/embroider/tree/HEAD/packages/test-setup) from 1.8.3 to 2.0.2.
- Bumps [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.6.1 to 11.0.6.

Minor:
- Bumps [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) from 7.18.10 to 7.21.0.
- Bumps [prettier](https://github.com/prettier/prettier) from 2.7.1 to 2.8.1.
- Bumps [ember-auto-import](https://github.com/ef4/ember-auto-import/tree/HEAD/packages/ember-auto-import) from 2.4.2 to 2.5.0.
- Bumps [webpack](https://github.com/webpack/webpack) from 5.74.0 to 5.75.0.
- Bumps [@babel/eslint-parser](https://github.com/babel/babel/tree/HEAD/eslint/babel-eslint-parser) from 7.18.2 to 7.19.1.
- Bumps [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) from 4.0.0 to 4.2.1.

Patch:
- Bumps [http-cache-semantics](https://github.com/kornelski/http-cache-semantics) from 4.1.0 to 4.1.1.
- Bumps [decode-uri-component](https://github.com/SamVerschueren/decode-uri-component) from 0.2.0 to 0.2.2.
- Bumps [loader-utils](https://github.com/webpack/loader-utils) from 1.4.0 to 1.4.2.
- Bumps [socket.io-parser](https://github.com/socketio/socket.io-parser) from 4.0.4 to 4.0.5.
- Bumps [mout](https://github.com/mout/mout) from 1.2.3 to 1.2.4.
- Bumps [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) from 6.1.0 to 6.1.1.