### PR TITLE
Release version 5.0.0

### DIFF
--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -1,81 +1,81 @@
 # GitHub Actions documentation:
 # https://docs.github.com/en/actions
 
-name: Create new tag, create new GitHub release and publish to NPM
+# name: Create new tag, create new GitHub release and publish to NPM
 
-on:
-  workflow_run:
-    workflows:
-      - CI
-    branches:
-      - master
-    types:
-      - completed
+# on:
+#   workflow_run:
+#     workflows:
+#       - CI
+#     branches:
+#       - master
+#     types:
+#       - completed
 
-concurrency:
-  group: tag-release-publish-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: tag-release-publish-${{ github.ref }}
+#   cancel-in-progress: true
 
-jobs:
-  create_git_tag:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: Create new tag
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    outputs:
-      new_tag: ${{ steps.detect_then_tag.outputs.tag }}
-      new_version: ${{ steps.detect_then_tag.outputs.current-version }}
-      old_version: ${{ steps.detect_then_tag.outputs.previous-version }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
+# jobs:
+#   create_git_tag:
+#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#     name: Create new tag
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 20
+#     outputs:
+#       new_tag: ${{ steps.detect_then_tag.outputs.tag }}
+#       new_version: ${{ steps.detect_then_tag.outputs.current-version }}
+#       old_version: ${{ steps.detect_then_tag.outputs.previous-version }}
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 2
 
-      - name: Detect and tag new version
-        id: detect_then_tag
-        uses: salsify/action-detect-and-tag-new-version@v2
+#       - name: Detect and tag new version
+#         id: detect_then_tag
+#         uses: salsify/action-detect-and-tag-new-version@v2
 
-  create_github_release:
-    if: ${{ needs.create_git_tag.outputs.new_tag }}
-    name: Create new GitHub release
-    needs: create_git_tag
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: ncipollo/release-action@v1
-        with:
-          body: "\
-            Changelog: \
-            ${{ github.server_url }}/${{ github.repository }}\
-            /compare/\
-            v${{ needs.create_git_tag.outputs.old_version }}...v${{ needs.create_git_tag.outputs.new_version }}\
-            "
-          name: Release ${{ needs.create_git_tag.outputs.new_tag }}
-          tag: ${{ needs.create_git_tag.outputs.new_tag }}
+#   create_github_release:
+#     if: ${{ needs.create_git_tag.outputs.new_tag }}
+#     name: Create new GitHub release
+#     needs: create_git_tag
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 20
+#     steps:
+#       - uses: ncipollo/release-action@v1
+#         with:
+#           body: "\
+#             Changelog: \
+#             ${{ github.server_url }}/${{ github.repository }}\
+#             /compare/\
+#             v${{ needs.create_git_tag.outputs.old_version }}...v${{ needs.create_git_tag.outputs.new_version }}\
+#             "
+#           name: Release ${{ needs.create_git_tag.outputs.new_tag }}
+#           tag: ${{ needs.create_git_tag.outputs.new_tag }}
 
-  publish_npm:
-    name: Publish to NPM
-    needs: create_github_release
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+#   publish_npm:
+#     name: Publish to NPM
+#     needs: create_github_release
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 20
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: 'yarn'
-          node-version: 16
-          registry-url: https://registry.npmjs.org
+#       - name: Set up Node.js
+#         uses: actions/setup-node@v3
+#         with:
+#           cache: 'yarn'
+#           node-version: 16
+#           registry-url: https://registry.npmjs.org
 
-      - name: Install Dependencies
-        run: yarn install --frozen-lockfile
-        working-directory: ember-slugify
+#       - name: Install Dependencies
+#         run: yarn install --frozen-lockfile
+#         working-directory: ember-slugify
 
-      - name: Publish to NPM
-        run: npm publish
-        working-directory: ember-slugify
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+#       - name: Publish to NPM
+#         run: npm publish
+#         working-directory: ember-slugify
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/ember-slugify/package.json
+++ b/ember-slugify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-slugify",
   "description": "Library to slugify your strings within Ember.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "license": "MIT",
   "author": {
     "name": "Dazzling Fugu",

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -28,6 +28,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
+            '@ember/string': '^3.1.1',
           },
         },
       },
@@ -36,6 +37,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            '@ember/string': '^3.1.1',
           },
         },
       },
@@ -47,6 +49,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            '@ember/string': '^3.1.1',
           },
         },
       },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-app",
   "description": "Library to slugify your strings within Ember.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "license": "MIT",
   "author": {
     "name": "Dazzling Fugu",
@@ -62,7 +62,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^9.0.1",
-    "ember-slugify": "4.0.0",
+    "ember-slugify": "5.0.0",
     "ember-source": "~4.8.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.0.1",


### PR DESCRIPTION
# Release version 5.0.0

## Breaking
### Migrate to V2 Addon (#258)
Follow the guide https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md to migrate `ember-slugify` to V2 Addon.

## Build

### Deactivate the release job for now
The Migration to V2 Addon #258 has broken the release job. We will fix it, but let's deactivate it for now so it doesn't interfere with a manual release of the addon.

### @dependabot bumps
Bumps [ember-resolver](https://github.com/ember-cli/ember-resolver) from 8.0.3 to 9.0.1.
Bumps [webpack](https://github.com/webpack/webpack) from 5.75.0 to 5.81.0.
Bumps [engine.io](https://github.com/socketio/engine.io) from 6.4.1 to 6.4.2.
Bumps [@babel/eslint-parser](https://github.com/babel/babel/tree/HEAD/eslint/babel-eslint-parser) from 7.19.1 to 7.21.3.
Bumps [emoji.json](https://github.com/amio/emoji.json) from 13.1.0 to 14.0.0.
Bumps [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) from 8.6.0 to 8.8.0.
Bumps [webpack](https://github.com/webpack/webpack) from 5.81.0 to 5.82.1.

## Test
### Add `@ember/string`
`@ember/string` is now included in the dev dependencies of the ember-try scenarios `release`, `beta` and `canary`. This is because this addon becomes required starting 4.12, but for now our project is in 4.8.
