### PR TITLE
Properly "disable" our GitHub workflow "tag, release and publish"

### DIFF
--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -3,14 +3,7 @@
 
 name: Create new tag, create new GitHub release and publish to NPM
 
-on:
-  workflow_run:
-    workflows:
-      - CI
-    branches:
-      - master
-    types:
-      - completed
+on: workflow_dispatch
 
 concurrency:
   group: tag-release-publish-${{ github.ref }}

--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -1,81 +1,81 @@
 # GitHub Actions documentation:
 # https://docs.github.com/en/actions
 
-# name: Create new tag, create new GitHub release and publish to NPM
+name: Create new tag, create new GitHub release and publish to NPM
 
-# on:
-#   workflow_run:
-#     workflows:
-#       - CI
-#     branches:
-#       - master
-#     types:
-#       - completed
+on:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - master
+    types:
+      - completed
 
-# concurrency:
-#   group: tag-release-publish-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: tag-release-publish-${{ github.ref }}
+  cancel-in-progress: true
 
-# jobs:
-#   create_git_tag:
-#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-#     name: Create new tag
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 20
-#     outputs:
-#       new_tag: ${{ steps.detect_then_tag.outputs.tag }}
-#       new_version: ${{ steps.detect_then_tag.outputs.current-version }}
-#       old_version: ${{ steps.detect_then_tag.outputs.previous-version }}
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 2
+jobs:
+  create_git_tag:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Create new tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      new_tag: ${{ steps.detect_then_tag.outputs.tag }}
+      new_version: ${{ steps.detect_then_tag.outputs.current-version }}
+      old_version: ${{ steps.detect_then_tag.outputs.previous-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-#       - name: Detect and tag new version
-#         id: detect_then_tag
-#         uses: salsify/action-detect-and-tag-new-version@v2
+      - name: Detect and tag new version
+        id: detect_then_tag
+        uses: salsify/action-detect-and-tag-new-version@v2
 
-#   create_github_release:
-#     if: ${{ needs.create_git_tag.outputs.new_tag }}
-#     name: Create new GitHub release
-#     needs: create_git_tag
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 20
-#     steps:
-#       - uses: ncipollo/release-action@v1
-#         with:
-#           body: "\
-#             Changelog: \
-#             ${{ github.server_url }}/${{ github.repository }}\
-#             /compare/\
-#             v${{ needs.create_git_tag.outputs.old_version }}...v${{ needs.create_git_tag.outputs.new_version }}\
-#             "
-#           name: Release ${{ needs.create_git_tag.outputs.new_tag }}
-#           tag: ${{ needs.create_git_tag.outputs.new_tag }}
+  create_github_release:
+    if: ${{ needs.create_git_tag.outputs.new_tag }}
+    name: Create new GitHub release
+    needs: create_git_tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: ncipollo/release-action@v1
+        with:
+          body: "\
+            Changelog: \
+            ${{ github.server_url }}/${{ github.repository }}\
+            /compare/\
+            v${{ needs.create_git_tag.outputs.old_version }}...v${{ needs.create_git_tag.outputs.new_version }}\
+            "
+          name: Release ${{ needs.create_git_tag.outputs.new_tag }}
+          tag: ${{ needs.create_git_tag.outputs.new_tag }}
 
-#   publish_npm:
-#     name: Publish to NPM
-#     needs: create_github_release
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 20
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
+  publish_npm:
+    name: Publish to NPM
+    needs: create_github_release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-#       - name: Set up Node.js
-#         uses: actions/setup-node@v3
-#         with:
-#           cache: 'yarn'
-#           node-version: 16
-#           registry-url: https://registry.npmjs.org
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: 16
+          registry-url: https://registry.npmjs.org
 
-#       - name: Install Dependencies
-#         run: yarn install --frozen-lockfile
-#         working-directory: ember-slugify
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: ember-slugify
 
-#       - name: Publish to NPM
-#         run: npm publish
-#         working-directory: ember-slugify
-#         env:
-#           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      - name: Publish to NPM
+        run: npm publish
+        working-directory: ember-slugify
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
This PR properly "_disables_" our GitHub workflow "tag, release and publish".

It is true the workflow was already disabled in #278 , but not correctly.
The workflow is still existing, but with no content, which is an invalid syntax for GitHub workflows.
Because of that, we are constantly getting the same error over and over:
- https://github.com/DazzlingFugu/ember-slugify/actions/workflows/tag-release-publish.yml

  ```
  [Error: .github#L1](https://github.com/DazzlingFugu/ember-slugify/commit/757ebfde5ba183ddcb9f28a097748ca7d596ece1#annotation_14567186151)
  No event triggers defined in `on`
  ```

We have 2 alternatives here:

1. To disable the workflow via GitHub web interface
   a. On this page https://github.com/DazzlingFugu/ember-slugify/actions/workflows/tag-release-publish.yml
   b. Click the `...` button in the top right corner > Disable workflow

2. To "disable" the workflow by making sure it can only be triggered manually.
   a. There is no syntax to "really disable" a workflow.

I went for option (2) so we can actually track this change, to see what happened to the workflow.
With option (1), one could not easily know why the workflow does not run.
