### PR TITLE
build: update `ember-cli` to v5.4.2

### DIFF
--- a/test-app/package.json
+++ b/test-app/package.json
@@ -69,7 +69,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.2.2",
     "ember-auto-import": "^2.7.2",
-    "ember-cli": "~5.4.1",
+    "ember-cli": "~5.4.2",
     "ember-cli-app-version": "^6.0.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5229,10 +5229,10 @@ ember-cli-version-checker@^5.1.1, ember-cli-version-checker@^5.1.2:
     semver "^7.3.4"
     silent-error "^1.1.1"
 
-ember-cli@~5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-5.4.1.tgz#248205ac0abdb970a7f578a729af99567c5e48fc"
-  integrity sha512-+jwp63OPT0zkUnXP563DkIwb1GiI6kGYHg6DyzJKY48BCdevqcgxsMFn8/RENXoF7krg18A5B9cSa8Y1v15tIw==
+ember-cli@~5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-5.4.2.tgz#d91c42ad6a974ba75d6ca87db9087b7c9730ffd3"
+  integrity sha512-EeeiTHo+rtat+YRv01q64Wmo+MRZETcZ7bPKBU14h9gSqSU0bHj57KGKsaQ+av8sOUojwWSqp+GQfOtwuWDgYA==
   dependencies:
     "@pnpm/find-workspace-dir" "^6.0.2"
     broccoli "^3.5.2"
@@ -5287,7 +5287,7 @@ ember-cli@~5.4.1:
     is-git-url "^1.0.0"
     is-language-code "^3.1.0"
     isbinaryfile "^5.0.0"
-    lodash.template "^4.5.0"
+    lodash "^4.17.21"
     markdown-it "^13.0.1"
     markdown-it-terminal "^0.4.0"
     minimatch "^7.4.3"
@@ -8344,13 +8344,6 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
-
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
 
 lru-cache@^7.5.1:
   version "7.18.3"
@@ -11775,11 +11768,6 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yam@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Build

#### Update `ember-cli` to v5.4.2

This update should address the security warning CVE-2021-23337:
- https://github.com/DazzlingFugu/ember-slugify/security/dependabot/57
- https://github.com/ember-cli/ember-cli/pull/10458
