### PR TITLE
Release v6.1.0

### DIFF
--- a/ember-slugify/package.json
+++ b/ember-slugify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-slugify",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Library to slugify your strings within Ember.",
   "keywords": [
     "accent",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.24.2", "@babel/code-frame@^7.24.7":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.24.2", "@babel/code-frame@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
   integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
@@ -146,7 +146,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-member-expression-to-functions@^7.23.0", "@babel/helper-member-expression-to-functions@^7.24.8":
+"@babel/helper-member-expression-to-functions@^7.24.8":
   version "7.24.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz#6155e079c913357d24a4c20480db7c712a5c3fb6"
   integrity sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==
@@ -224,7 +224,7 @@
   dependencies:
     "@babel/types" "^7.24.5"
 
-"@babel/helper-string-parser@^7.24.1", "@babel/helper-string-parser@^7.24.8":
+"@babel/helper-string-parser@^7.24.8":
   version "7.24.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz#5b3329c9a58803d5df425e5785865881a81ca48d"
   integrity sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==
@@ -257,7 +257,7 @@
     "@babel/traverse" "^7.24.5"
     "@babel/types" "^7.24.5"
 
-"@babel/highlight@^7.24.2", "@babel/highlight@^7.24.7":
+"@babel/highlight@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.7.tgz#a05ab1df134b286558aae0ed41e6c5f731bf409d"
   integrity sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==
@@ -267,7 +267,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.14.5", "@babel/parser@^7.24.0", "@babel/parser@^7.24.5", "@babel/parser@^7.25.0", "@babel/parser@^7.25.3", "@babel/parser@^7.4.5":
+"@babel/parser@^7.14.5", "@babel/parser@^7.24.5", "@babel/parser@^7.25.0", "@babel/parser@^7.25.3", "@babel/parser@^7.4.5":
   version "7.25.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.3.tgz#91fb126768d944966263f0657ab222a642b82065"
   integrity sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==


### PR DESCRIPTION
## Build

- Use `ember-slugify@6.0.0` in the test-app (#311)
- Update `ember-cli` to v5.4.2 (#357)
- Update `eslint` to latest version 8 (#362)

#### @dependabot

- Bump stylelint-config-standard from 34.0.0 to 35.0.0 (#312)
- Bump typescript from 5.3.2 to 5.3.3 (#313)
- Bump @embroider/addon-dev from 4.1.2 to 4.1.3 (#314)
- Bump stylelint from 15.11.0 to 16.0.2 (#317)
- Bump stylelint from 16.0.2 to 16.1.0 (#318)
- Bump @babel/plugin-transform-typescript from 7.23.5 to 7.23.6 (#319)
- Bump eslint-plugin-n from 16.3.1 to 16.6.1 (#320)
- Bump eslint-plugin-prettier from 5.0.1 to 5.1.2 (#321)
- Bump follow-redirects from 1.15.3 to 1.15.4 (#322)
- Bump ember-auto-import from 2.7.0 to 2.7.2 (#323)
- Bump prettier from 3.1.0 to 3.2.1 (#324)
- Bump stylelint from 16.1.0 to 16.2.0 (#325)
- Bump @types/ember__service from 4.0.8 to 4.0.9 (#326)
- Bump @types/ember__application from 4.0.10 to 4.0.11 (#327)
- Bump @types/qunit from 2.19.9 to 2.19.10 (#328)
- Bump eslint-plugin-prettier from 5.1.2 to 5.1.3 (#330)
- Bump @types/ember__runloop from 4.0.8 to 4.0.10 (#331)
- Bump stylelint from 16.2.0 to 16.2.1 (#332)
- Bump rollup from 3.29.4 to 4.12.0 (#333)
- Bump @types/ember__owner from 4.0.8 to 4.0.9 (#334)
- Bump @types/ember__template from 4.0.5 to 4.0.7 (#335)
- Bump eslint-plugin-ember from 11.11.1 to 12.0.2 (#336)
- Bump @types/ember__array from 4.0.9 to 4.0.10 (#337)
- Bump @types/ember__component from 4.0.21 to 4.0.22 (#338)
- Bump eslint-plugin-n from 16.6.1 to 16.6.2 (#339)
- Bump @glint/environment-ember-template-imports from 1.2.1 to 1.3.0 (#340)
- Bump @types/ember__debug from 4.0.7 to 4.0.8 (#341)
- Bump @types/ember__modifier from 4.0.8 to 4.0.9 (#342)
- Bump follow-redirects from 1.15.4 to 1.15.6 (#343)
- Bump @babel/plugin-transform-typescript from 7.23.6 to 7.24.1 (#344)
- Bump @types/ember__object from 4.0.11 to 4.0.12 (#345)
- Bump express from 4.18.2 to 4.19.2 (#346)
- Bump @glint/template from 1.2.1 to 1.4.0 (#347)
- Bump @types/ember-data__model from 4.0.4 to 4.0.5 (#348)
- Bump ember-template-lint from 5.13.0 to 6.0.0 (#349)
- Bump @typescript-eslint/eslint-plugin from 6.13.1 to 7.5.0 (#350)
- Bump @types/ember__polyfills from 4.0.5 to 4.0.6 (#351)
- Bump prettier-plugin-ember-template-tag from 1.1.0 to 2.0.2 (#352)
- Bump @ember/test-helpers from 3.2.1 to 3.3.0 (#353)
- Bump @embroider/addon-dev from 4.1.3 to 4.3.1 (#354)
- Bump @glint/environment-ember-template-imports from 1.3.0 to 1.4.0 (#355)
- Bump ember-source from 5.4.0 to 5.8.0 (#356)
- Bump @babel/core from 7.24.4 to 7.24.5 (#358)
- Bump @types/ember__routing from 4.0.19 to 4.0.22 (#359)
- Bump @ember/optional-features from 2.0.0 to 2.1.0 (#360)
- Bump @typescript-eslint/parser from 6.13.1 to 7.8.0 (#361)
- Bump @typescript-eslint/eslint-plugin from 7.5.0 to 7.9.0 (#363)
- Bump @babel/plugin-transform-class-static-block from 7.23.4 to 7.24.4 (#364)
- Bump stylelint from 16.2.1 to 16.6.0 (#365)
- Bump @types/ember__destroyable from 4.0.4 to 4.0.5 (#366)
- Bump @types/ember-data__store from 4.0.6 to 4.0.7 (#367)
- Bump @types/ember__error from 4.0.5 to 4.0.6 (#368)
- Bump ember-source from 5.8.0 to 5.9.0 (#369)
- Bump stylelint-config-standard from 35.0.0 to 36.0.0 (#370)
- Bump qunit-dom from 2.0.0 to 3.1.2 (#371)
- Bump ember-qunit from 8.0.2 to 8.1.0 (#372)
- Bump ws from 7.5.9 to 7.5.10 (#373)
- Bump eslint-plugin-n from 16.6.2 to 17.9.0 (#374)
- Bump ember-page-title from 8.1.0 to 8.2.3 (#375)
- Bump ember-auto-import from 2.7.2 to 2.7.4 (#376)
- Bump @tsconfig/ember from 2.0.0 to 3.0.8 (#377)
- Bump @types/ember__helper from 4.0.5 to 4.0.8 (#378)
- Bump @types/ember from 4.0.10 to 4.0.11 (#379)
- Bump stylelint-config-standard from 36.0.0 to 36.0.1 (#380)
- Bump @types/ember__engine from 4.0.10 to 4.0.11 (#381)
- Bump @embroider/test-setup from 3.0.3 to 4.0.0 (#382)
- Bump @types/ember__controller from 4.0.11 to 4.0.12 (#383)
- Bump typescript from 5.3.3 to 5.5.4 (#384)
- Bump ember-cli-app-version from 6.0.1 to 7.0.0 (#385)
- Bump rollup from 4.12.0 to 4.19.2 (#386)
- Bump stylelint-prettier from 4.1.0 to 5.0.2 (#387)
- Bump @glint/environment-ember-loose from 1.2.1 to 1.4.0 (#388)
- Bump @babel/plugin-transform-class-static-block (#389)
- Bump @types/ember__test from 4.0.5 to 4.0.6 (#390)
- Bump @types/ember__utils from 4.0.6 to 4.0.7 (#391)
