### PR TITLE
revert: "build(deps-dev): bump eslint-plugin-ember from 12.2.0 to 12.…

### DIFF
--- a/ember-slugify/package.json
+++ b/ember-slugify/package.json
@@ -112,7 +112,7 @@
     "ember-template-lint": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-ember": "^12.3.1",
+    "eslint-plugin-ember": "^12.2.0",
     "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-qunit": "^8.1.2",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -92,7 +92,7 @@
     "ember-try": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-ember": "^12.3.1",
+    "eslint-plugin-ember": "^12.2.0",
     "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-qunit": "^8.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,10 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@^7.23.10":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz#603c68a63078796527bc9d0833f5e52dd5f9224c"
-  integrity sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==
+"@babel/eslint-parser@7.23.10":
+  version "7.23.10"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz#2d4164842d6db798873b40e0c4238827084667a2"
+  integrity sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -5270,14 +5270,14 @@ ember-data@~5.3.0:
     ember-inflector "^4.0.2"
     webpack "^5.88.2"
 
-ember-eslint-parser@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.5.3.tgz#48dc93529ec942c117fffd6265be2017bd94aaef"
-  integrity sha512-FYsoiVcGUGDAybPq8X551hcs9NA0SDx77kfU1sHCTLYqfG4zQ0Rcy+lGxoaXaskH7sTf+Up3/oVyjx/+nJ3joA==
+ember-eslint-parser@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.4.3.tgz#a7ca3c380872719610b94c7a06cc550ced745031"
+  integrity sha512-wMPoaaA+i/F/tPPxURRON9XXJH5MRUOZ5x/9CVJTSpL+0n4EWphyztb20gR+ZJeShnOACQpAdFy6YSS1/JSHKw==
   dependencies:
-    "@babel/eslint-parser" "^7.23.10"
+    "@babel/eslint-parser" "7.23.10"
     "@glimmer/syntax" "^0.92.0"
-    content-tag "^2.0.1"
+    content-tag "^1.2.2"
     eslint-scope "^7.2.2"
     html-tags "^3.3.1"
 
@@ -5738,14 +5738,14 @@ eslint-formatter-kakoune@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-formatter-kakoune/-/eslint-formatter-kakoune-1.0.0.tgz#a95cc4fe1fbc06b84e0f2397e83f5f0b68340125"
   integrity sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==
 
-eslint-plugin-ember@^12.3.1:
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-12.3.1.tgz#6d9368141f1c685f89f96fd0143350481f91cdcc"
-  integrity sha512-Ew8E7R0inU7HSQZ7ChixLvv4y3wtyC++9DYBmAYyjtRoM+p/PwP2kUkyKYJTLi5v5IuSR+fS3IWtbswoq9bPyQ==
+eslint-plugin-ember@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-12.2.0.tgz#6f584c941debd41f174ad022a117ee0d52a20103"
+  integrity sha512-Pf0LB70qzrGqbxrieASFDqxvGu7/xgejM78Kj+VsH27XqkuoluF1M5fBU5xxNB7oRCpA5IFA5jdN9WnnSjLzKA==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
     css-tree "^2.3.1"
-    ember-eslint-parser "^0.5.3"
+    ember-eslint-parser "^0.4.3"
     ember-rfc176-data "^0.3.18"
     eslint-utils "^3.0.0"
     estraverse "^5.3.0"


### PR DESCRIPTION
This PR reverts the PR #417 .

Somehow, since #417 was merged, `master` has been failing
- https://github.com/DazzlingFugu/ember-slugify/actions/runs/11539496516

and even other unrelated branches like #416
- https://github.com/DazzlingFugu/ember-slugify/actions/runs/11539690228?pr=416

Let's roll back to see if things can go back to normal.

---

**Edit**

I should have inspected the logs better:

https://github.com/DazzlingFugu/ember-slugify/actions/runs/11539802642/job/32119898457?pr=418

we can see:

```
error Couldn't find package "@rollup/rollup-freebsd-arm64@4.24.1" required by "rollup@^4.22.5" on the "npm" registry.
```

which leads to:

https://github.com/rollup/rollup/issues/5704 .